### PR TITLE
Update error page and css

### DIFF
--- a/LightTube/Views/Shared/Player.cshtml
+++ b/LightTube/Views/Shared/Player.cshtml
@@ -15,14 +15,29 @@
 	{
 		@if (Model.Exception is PlayerException e)
 		{
-			@:[@e.Code] @e.Error
-			<br>
-			@e.Description
-			
-			@if (e.Code == "CONTENT_CHECK_REQUIRED")
-			{
-				<a href="@Context.Request.Path.ToString()@Context.Request.QueryString&contentCheckOk=true">I understand and wish to proceed</a>
-			}
+			<div class="player-error-container">
+				<div class="player-error-icon">
+					<svg class="icon" fill="currentColor" style="color: white;" width="128" height="128">
+						<use xlink:href="/svg/bootstrap-icons.svg#exclamation-circle"></use>
+					</svg>
+				</div>
+				<div class="player-error-info">
+					@if (e.Code == "LOGIN_REQUIRED")
+					{
+						<div class="title" title="[@e.Code] @e.Error">@e.Error</div>
+						<p class="ml-1">Please contact the instance administrator to include InnerTube login details</p>
+					}
+					else
+					{
+						<div class="title" title="[@e.Code] @e.Error">@e.Error</div>
+						<p class="ml-1">@e.Description</p>
+						@if (e.Code is "CONTENT_CHECK_REQUIRED" or "AGE_CHECK_REQUIRED")
+						{
+							<a href="@Context.Request.Path.ToString()@Context.Request.QueryString&contentCheckOk=true" class="btn-white">I understand and wish to proceed</a>
+						}
+					}
+				</div>
+			</div>
 		}
 		else
 		{

--- a/LightTube/wwwroot/css/lighttube.css
+++ b/LightTube/wwwroot/css/lighttube.css
@@ -24,6 +24,7 @@ html:root {
 
 	/* Button colors */
 	--btn-hover-color-blue: #def1ff;
+	--btn-hover-color-white: #aaa;
 
 	--chip-background: rgb(0, 0, 0, 0.05);
 	--chip-background-hover: rgb(0, 0, 0, 0.10);
@@ -518,6 +519,7 @@ body.no-guide .guide {
 	-ms-user-select: none;
 	-webkit-user-select: none;
 	border-radius: 18px;
+	width: fit-content;
 }
 
 *[class^="btn"]:hover {
@@ -546,6 +548,17 @@ body.no-guide .guide {
 
 .btn-blue:hover {
 	background-color: var(--btn-hover-color-blue);
+}
+
+.btn-white, .btn-white > svg {
+	background-color: #fff;
+	color: #000;
+}
+
+.btn-white:hover {
+	background-color: var(--btn-hover-color-white);
+	border-color: var(--btn-hover-color-white);
+	color: #000;
 }
 
 .btn-outline {
@@ -634,6 +647,34 @@ body.no-guide .guide {
 .player {
 	width: 100%;
 	height: 100%;
+}
+
+.player-error-container {
+	display: flex;
+	flex-direction: row;
+	align-items: center;
+	padding: 0 20%;
+	height: 100%;
+	gap: 32px;
+}
+
+@media screen and (max-width: 1085px) {
+	.player-error-container {
+		padding: 8px;
+	}
+	
+	.player-error-container svg {
+		width: 32px;
+		height: 32px;
+	}
+}
+
+.player-error-container *:not(a) {
+	color: white;
+}
+
+.player-error-container .title {
+	font-size: 1.3rem;
 }
 
 .playlist-view-container {

--- a/LightTube/wwwroot/css/lighttube.css
+++ b/LightTube/wwwroot/css/lighttube.css
@@ -771,6 +771,9 @@ body.no-guide .guide {
 
 .info-container > .description > summary {
 	font-weight: bold;
+	margin: -16px;
+	padding: 16px;
+	cursor: pointer;
 }
 
 .info-container > .description > a {

--- a/LightTube/wwwroot/css/renderers.css
+++ b/LightTube/wwwroot/css/renderers.css
@@ -16,7 +16,7 @@
     text-decoration: none;
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 1085px) {
     .compact-thumbnail {
         min-width: initial;
         min-height: initial;
@@ -294,7 +294,7 @@
 
 /* Compact renderers generic */
 
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 1085px) {
     .compact-renderer-list {
         width: 400px;
         display: flex;
@@ -308,7 +308,7 @@
     }
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 1085px) {
     .compact-renderer-list {
         width: 100%;
         display: flex;
@@ -350,7 +350,7 @@
 }
 
 /* Compact Video Renderer, Compact Playlist Renderer, Compact Radio Renderer */
-@media screen and (min-width: 700px) {
+@media screen and (min-width: 1085px) {
     .renderer-compactvideorenderer,
     .renderer-compactplaylistrenderer,
     .renderer-compactradiorenderer {
@@ -361,7 +361,7 @@
     }
 }
 
-@media screen and (max-width: 700px) {
+@media screen and (max-width: 1085px) {
     .renderer-compactvideorenderer,
     .renderer-compactplaylistrenderer,
     .renderer-compactradiorenderer {


### PR DESCRIPTION
# Details
Fixes the error page so it isn't just some ugly text

# Changes proposed
* Update the error page to be more user friendly
* Slight CSS fixes 
    * Make sure compact renderers expand on mobile layout
    * Make the description summary hitbox cover the entire element while collapsed & change the cursor while hovering

# Notes
Also adds the "This video may be inappropriate for some users." button on videos that throw an `AGE_CHECK_REQUIRED` error
