### PR TITLE
Fix shorts redirecting to an invalid URL

### DIFF
--- a/LightTube/Controllers/YoutubeController.cs
+++ b/LightTube/Controllers/YoutubeController.cs
@@ -217,7 +217,7 @@ public class YoutubeController : Controller
 	}
 
 	[Route("/shorts/{v}")]
-	public IActionResult Shorts(string v) => RedirectPermanent("/watch?v={v}");
+	public IActionResult Shorts(string v) => RedirectPermanent($"/watch?v={v}");
 
 	[Route("/download/{v}")]
 	public async Task<IActionResult> Download(string v)

--- a/LightTube/LightTube.csproj
+++ b/LightTube/LightTube.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="InnerTube" Version="1.0.10" />
+        <PackageReference Include="InnerTube" Version="1.0.11" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
         <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />


### PR DESCRIPTION
# Details
Short links (`/shorts/<videoId>`) would redirect to `/watch?v={0}` because of a small typo

# Related issues/PRs
Fixes #26 

# Notes
Also updates InnerTube version to fix some about pages being broken
