### PR TITLE
Implement multi audio tracks

### DIFF
--- a/LightTube/LightTube.csproj
+++ b/LightTube/LightTube.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="InnerTube" Version="1.0.12" />
+        <PackageReference Include="InnerTube" Version="1.0.13" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
         <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/LightTube/Utils.cs
+++ b/LightTube/Utils.cs
@@ -20,15 +20,15 @@ public static class Utils
 	public static string UserIdAlphabet => "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_";
 
 	public static string GetRegion(this HttpContext context) =>
-		context.Request.Headers.TryGetValue("X-Content-Region", out StringValues h) 
-			? h.ToString() 
+		context.Request.Headers.TryGetValue("X-Content-Region", out StringValues h)
+			? h.ToString()
 			: context.Request.Cookies.TryGetValue("gl", out string region)
-				? region 
+				? region
 				: Configuration.GetVariable("LIGHTTUBE_DEFAULT_CONTENT_REGION", "US");
 
 	public static string GetLanguage(this HttpContext context) =>
-		context.Request.Headers.TryGetValue("X-Content-Language", out StringValues h) 
-			? h.ToString() 
+		context.Request.Headers.TryGetValue("X-Content-Language", out StringValues h)
+			? h.ToString()
 			: context.Request.Cookies.TryGetValue("hl", out string language)
 				? language
 				: Configuration.GetVariable("LIGHTTUBE_DEFAULT_CONTENT_LANGUAGE", "en");
@@ -68,7 +68,8 @@ public static class Utils
 		}
 	}
 
-	public static async Task<string> GetProxiedHlsManifest(string url, string? proxyRoot = null, bool skipCaptions = false)
+	public static async Task<string> GetProxiedHlsManifest(string url, string? proxyRoot = null,
+		bool skipCaptions = false)
 	{
 		if (!url.StartsWith("http://") && !url.StartsWith("https://"))
 			url = "https://" + url;
@@ -182,53 +183,67 @@ public static class Utils
 
 		XmlElement period = doc.CreateElement("Period");
 
-		period.AppendChild(doc.CreateComment("Audio Adaptation Set"));
-		XmlElement audioAdaptationSet = doc.CreateElement("AdaptationSet");
+		period.AppendChild(doc.CreateComment("Audio Adaptation Sets"));
 		List<Format> audios = player.AdaptiveFormats
 			.Where(x => x.AudioChannels.HasValue)
 			.ToList();
-
-		audioAdaptationSet.SetAttribute("mimeType",
-			HttpUtility.ParseQueryString(audios.First().Url.Query).Get("mime"));
-		audioAdaptationSet.SetAttribute("subsegmentAlignment", "true");
-		audioAdaptationSet.SetAttribute("contentType", "audio");
-		foreach (Format format in audios)
+		IEnumerable<IGrouping<string?, Format>> grouped = audios.GroupBy(x => x.AudioTrack?.Id);
+		foreach (IGrouping<string?, Format> formatGroup in grouped.OrderBy(x => x.First().AudioTrack?.AudioIsDefault))
 		{
-			XmlElement representation = doc.CreateElement("Representation");
-			representation.SetAttribute("id", format.Itag);
-			representation.SetAttribute("codecs", GetCodecFromMimeType(format.MimeType));
-			representation.SetAttribute("startWithSAP", "1");
-			representation.SetAttribute("bandwidth", format.Bitrate.ToString());
+			XmlElement audioAdaptationSet = doc.CreateElement("AdaptationSet");
 
-			XmlElement audioChannelConfiguration = doc.CreateElement("AudioChannelConfiguration");
-			audioChannelConfiguration.SetAttribute("schemeIdUri",
-				"urn:mpeg:dash:23003:3:audio_channel_configuration:2011");
-			audioChannelConfiguration.SetAttribute("value", "2");
-			representation.AppendChild(audioChannelConfiguration);
+			audioAdaptationSet.SetAttribute("mimeType",
+				HttpUtility.ParseQueryString(audios.First().Url.Query).Get("mime"));
+			audioAdaptationSet.SetAttribute("subsegmentAlignment", "true");
+			audioAdaptationSet.SetAttribute("contentType", "audio");
+			audioAdaptationSet.SetAttribute("lang", formatGroup.Key);
 
-			XmlElement baseUrl = doc.CreateElement("BaseURL");
-			baseUrl.InnerText = string.IsNullOrWhiteSpace(proxyUrl)
-				? format.Url.ToString()
-				: $"{proxyUrl}/media/{player.Details.Id}/{format.Itag}";
-			representation.AppendChild(baseUrl);
-
-			if (format.IndexRange != null && format.InitRange != null)
+			if (formatGroup.First().AudioTrack != null)
 			{
-				XmlElement segmentBase = doc.CreateElement("SegmentBase");
-				segmentBase.SetAttribute("indexRange", $"{format.IndexRange.Start}-{format.IndexRange.End}");
-				segmentBase.SetAttribute("indexRangeExact", "true");
-
-				XmlElement initialization = doc.CreateElement("Initialization");
-				initialization.SetAttribute("range", $"{format.InitRange.Start}-{format.InitRange.End}");
-
-				segmentBase.AppendChild(initialization);
-				representation.AppendChild(segmentBase);
+				XmlElement label = doc.CreateElement("Label");
+				label.InnerText = formatGroup.First().AudioTrack?.DisplayName;
+				audioAdaptationSet.AppendChild(label);
 			}
 
-			audioAdaptationSet.AppendChild(representation);
-		}
+			foreach (Format format in formatGroup)
+			{
+				XmlElement representation = doc.CreateElement("Representation");
+				representation.SetAttribute("id", format.Itag);
+				representation.SetAttribute("codecs", GetCodecFromMimeType(format.MimeType));
+				representation.SetAttribute("startWithSAP", "1");
+				representation.SetAttribute("bandwidth", format.Bitrate.ToString());
 
-		period.AppendChild(audioAdaptationSet);
+				XmlElement audioChannelConfiguration = doc.CreateElement("AudioChannelConfiguration");
+				audioChannelConfiguration.SetAttribute("schemeIdUri",
+					"urn:mpeg:dash:23003:3:audio_channel_configuration:2011");
+				audioChannelConfiguration.SetAttribute("value", format.AudioChannels?.ToString());
+				representation.AppendChild(audioChannelConfiguration);
+
+				XmlElement baseUrl = doc.CreateElement("BaseURL");
+				baseUrl.InnerText = string.IsNullOrWhiteSpace(proxyUrl)
+					? format.Url.ToString()
+					: $"{proxyUrl}/media/{player.Details.Id}/{format.Itag}?audioTrackId={format.AudioTrack?.Id}";
+				representation.AppendChild(baseUrl);
+
+				if (format.IndexRange != null && format.InitRange != null)
+				{
+					XmlElement segmentBase = doc.CreateElement("SegmentBase");
+					// sometimes wrong?? idk
+					segmentBase.SetAttribute("indexRange", $"{format.IndexRange.Start}-{format.IndexRange.End}");
+					segmentBase.SetAttribute("indexRangeExact", "true");
+
+					XmlElement initialization = doc.CreateElement("Initialization");
+					initialization.SetAttribute("range", $"{format.InitRange.Start}-{format.InitRange.End}");
+
+					segmentBase.AppendChild(initialization);
+					representation.AppendChild(segmentBase);
+				}
+
+				audioAdaptationSet.AppendChild(representation);
+			}
+
+			period.AppendChild(audioAdaptationSet);
+		}
 
 		period.AppendChild(doc.CreateComment("Video Adaptation Set"));
 
@@ -345,7 +360,8 @@ public static class Utils
 			format.MimeType
 				.Split("/").Last()
 				.Split(";").First();
-		else {
+		else
+		{
 			if (format.MimeType.Contains("opus"))
 				return "opus";
 			if (format.MimeType.Contains("mp4a"))

--- a/LightTube/Views/Shared/Renderer.cshtml
+++ b/LightTube/Views/Shared/Renderer.cshtml
@@ -68,7 +68,7 @@
 					}
 				</a>
 				<div class="info__more">
-					@channel.SubscriberCountText • @channel.VideoCountText
+					@channel.UserHandle • @channel.SubscriberCountText
 				</div>
 			</div>
 			<div class="subscribe-container">


### PR DESCRIPTION
# Details
Implement multi-audio tracks available in some videos (example: https://tube.kuylar.dev/watch?v=4ZX9T0kWb4Y)

# Changes proposed
* Update InnerTube
* Add mutli-audio tracks into the MPD proxy
  * As the HLS proxy is sent by YouTube, and only slightly modified to proxy the URLs, it isn't supported

# Notes
thank you video.js for just working with the small change <3
