### PR TITLE
Fix the YouTube links in video descriptions going outside LightTube

### DIFF
--- a/LightTube/Views/Youtube/Watch.cshtml
+++ b/LightTube/Views/Youtube/Watch.cshtml
@@ -3,6 +3,8 @@
 
 @{
 	Model.Title = Model.Video.Title;
+	string desc = Model.Video.Description;
+	desc = desc.Replace("youtube.com", Context.Request.Host.ToString());
 }
 
 <div class="watch-page">
@@ -76,7 +78,7 @@
 			<summary>
 				@Model.Video.ViewCount • @Model.Video.DateText • Click to toggle description
 			</summary>
-			@Html.Raw(Model.Video.Description)
+			@Html.Raw(desc)
 		</details>
 	</div>
 	<div class="comments-container">


### PR DESCRIPTION
# Details
The description still had `youtube.com` links in it

# Changes proposed
* Replace `youtube.com` in descriptions with the request host