### PR TITLE
API fixes & Clearing unused tokens

### DIFF
--- a/LightTube/Controllers/OAuth2Controller.cs
+++ b/LightTube/Controllers/OAuth2Controller.cs
@@ -123,7 +123,7 @@ public class OAuth2Controller : Controller
 	{
 		if (Configuration.GetVariable("LIGHTTUBE_DISABLE_OAUTH", "")?.ToLower() == "true")
 			return Unauthorized();
-		if (grantType is not ("code" or "authorization_code"))
+		if (grantType is not ("code" or "authorization_code" or "refresh_token"))
 			return Unauthorized();
 		DatabaseOauthToken? token = await DatabaseManager.Oauth2.RefreshToken(code, clientId);
 		if (token is null) return Unauthorized();

--- a/LightTube/Controllers/OAuth2Controller.cs
+++ b/LightTube/Controllers/OAuth2Controller.cs
@@ -117,6 +117,7 @@ public class OAuth2Controller : Controller
 	public async Task<IActionResult> GrantTokenAsync(
 		[FromForm(Name = "grant_type")] string grantType,
 		[FromForm(Name = "code")] string code,
+		[FromForm(Name = "refresh_token")] string refreshToken,
 		[FromForm(Name = "redirect_uri")] string redirectUri,
 		[FromForm(Name = "client_id")] string clientId,
 		[FromForm(Name = "client_secret")] string clientSecret)
@@ -125,7 +126,7 @@ public class OAuth2Controller : Controller
 			return Unauthorized();
 		if (grantType is not ("code" or "authorization_code" or "refresh_token"))
 			return Unauthorized();
-		DatabaseOauthToken? token = await DatabaseManager.Oauth2.RefreshToken(code, clientId);
+		DatabaseOauthToken? token = await DatabaseManager.Oauth2.RefreshToken(refreshToken ?? code, clientId);
 		if (token is null) return Unauthorized();
 		return Json(new Oauth2CodeGrantResponse(token));
 	}

--- a/LightTube/Controllers/OauthApiController.cs
+++ b/LightTube/Controllers/OauthApiController.cs
@@ -35,12 +35,13 @@ public class OauthApiController : Controller
 
 	[Route("currentUser")]
 	[ApiAuthorization]
-	public async Task<IActionResult> GetCurrentUser()
+	public async Task<ApiResponse<DatabaseUser>> GetCurrentUser()
 	{
 		DatabaseUser? user = await DatabaseManager.Oauth2.GetUserFromHttpRequest(Request);
-		if (user is null) return Unauthorized();
+		if (user is null) return Error<DatabaseUser>("Unauthorized", 401, HttpStatusCode.Unauthorized);
 
-		return Json(user);
+		ApiUserData? userData = ApiUserData.GetFromDatabaseUser(user);
+		return new ApiResponse<DatabaseUser>(user, userData);
 	}
 
 	#region playlists.*
@@ -107,7 +108,8 @@ public class OauthApiController : Controller
 	[Route("playlists/{playlistId}/{videoId}")]
 	[HttpPut]
 	[ApiAuthorization("playlists.write")]
-	public async Task<ApiResponse<ModifyPlaylistContentResponse>> PutVideoIntoPlaylist(string playlistId, string videoId)
+	public async Task<ApiResponse<ModifyPlaylistContentResponse>> PutVideoIntoPlaylist(string playlistId,
+		string videoId)
 	{
 		DatabaseUser? user = await DatabaseManager.Oauth2.GetUserFromHttpRequest(Request);
 		if (user is null) return Error<ModifyPlaylistContentResponse>("Unauthorized", 401, HttpStatusCode.Unauthorized);

--- a/LightTube/Database/UserManager.cs
+++ b/LightTube/Database/UserManager.cs
@@ -92,8 +92,8 @@ public class UserManager
 			Token = Utils.GenerateToken(256),
 			UserAgent = userAgent,
 			Scopes = scopes.ToArray(),
-			Created = DateTimeOffset.Now,
-			LastSeen = DateTimeOffset.Now
+			Created = DateTimeOffset.UtcNow,
+			LastSeen = DateTimeOffset.UtcNow
 		};
 		await TokensCollection.InsertOneAsync(login);
 		return login;

--- a/LightTube/Database/UserManager.cs
+++ b/LightTube/Database/UserManager.cs
@@ -39,7 +39,8 @@ public class UserManager
 		if (token.StartsWith("Bearer "))
 		{
 			token = token.Split(" ")[1];
-			IAsyncCursor<DatabaseOauthToken> loginCursor = await Oauth2TokensCollection.FindAsync(x => x.CurrentAuthToken == token);
+			IAsyncCursor<DatabaseOauthToken> loginCursor =
+				await Oauth2TokensCollection.FindAsync(x => x.CurrentAuthToken == token);
 			DatabaseOauthToken login = await loginCursor.FirstOrDefaultAsync();
 			if (login is null) return null;
 
@@ -50,7 +51,12 @@ public class UserManager
 		{
 			IAsyncCursor<DatabaseLogin> loginCursor = await TokensCollection.FindAsync(x => x.Token == token);
 			DatabaseLogin login = await loginCursor.FirstOrDefaultAsync();
+
 			if (login is null) return null;
+
+			await TokensCollection.FindOneAndUpdateAsync(
+				Builders<DatabaseLogin>.Filter.Eq(x => x.Id, login.Id),
+				Builders<DatabaseLogin>.Update.Set(x => x.LastSeen, DateTimeOffset.UtcNow));
 
 			IAsyncCursor<DatabaseUser> userCursor = await UserCollection.FindAsync(x => x.UserID == login.UserID);
 			return await userCursor.FirstOrDefaultAsync();

--- a/LightTube/Views/Youtube/Watch.cshtml
+++ b/LightTube/Views/Youtube/Watch.cshtml
@@ -3,6 +3,8 @@
 
 @{
 	Model.Title = Model.Video.Title;
+	string desc = Model.Video.Description;
+	desc = desc.Replace("youtube.com", Context.Request.Host.ToString());
 }
 
 <div class="watch-page">
@@ -76,7 +78,7 @@
 			<summary>
 				@Model.Video.ViewCount • @Model.Video.DateText • Click to toggle description
 			</summary>
-			@Html.Raw(Model.Video.Description)
+			@Html.Raw(desc)
 		</details>
 	</div>
 	<div class="comments-container">


### PR DESCRIPTION
# Details
Fixes API issues related to OAuth2 & automatically clears tokens that aren't used for 30 days

# Changes proposed
* Fix the unwrapped API response in `/api/currentUser`
* Fix the OAuth2 token endpoint returning a `401` while refreshing
* Actually update the LastSeen property in the tokens
* Delete old logins in the database