### PR TITLE
Fix Livestreams & the API

### DIFF
--- a/LightTube/ApiModels/ApiPlaylist.cs
+++ b/LightTube/ApiModels/ApiPlaylist.cs
@@ -68,7 +68,15 @@ public class ApiPlaylist
 			Subscribers = null,
 			Badges = Array.Empty<Badge>()
 		};
-		Thumbnails = Array.Empty<Thumbnail>();
+		Thumbnails = new []
+		{
+			new Thumbnail
+			{
+				Width = null,
+				Height = null,
+				Url = new Uri($"https://i.ytimg.com/vi/{playlist.VideoIds.FirstOrDefault()}/hqdefault.jpg")
+			}
+		};
 		LastUpdated = $"Last updated on {playlist.LastUpdated:MMM d, yyyy}";
 		VideoCountText = playlist.VideoIds.Count switch
 		{

--- a/LightTube/Contexts/PlayerContext.cs
+++ b/LightTube/Contexts/PlayerContext.cs
@@ -40,7 +40,7 @@ public class PlayerContext : BaseContext
 
 	public Format? GetPreferredFormat() =>
 		Player?.Formats.FirstOrDefault(x => x.Itag == PreferredItag && x.Itag != "17") ??
-		Player?.Formats.First(x => x.Itag != "17");
+		Player?.Formats.FirstOrDefault(x => x.Itag != "17");
 
 	public string GetClass() => ClassName is not null ? $" {ClassName}" : "";
 

--- a/LightTube/Views/Youtube/Watch.cshtml
+++ b/LightTube/Views/Youtube/Watch.cshtml
@@ -12,21 +12,24 @@
 <div class="watch-page">
 	<div class="player-container" style="color:white;margin-bottom:2rem">
 		<partial name="Player" model="Model.Player"/>
-		<noscript>
-			<div class="noscript-quality-switcher">
-				Current video resolution:
-				<b>
-					@Model.Player.GetPreferredFormat()?.QualityLabel
-				</b>
-				Switch to
-				@foreach (Format f in Model.Player.Player?.Formats?.Where(x => x.Itag != Model.Player.GetFirstItag()) ?? Array.Empty<Format>())
-				{
+		@if (!Model.Player.Player?.Details.IsLive ?? true)
+		{
+			<noscript>
+				<div class="noscript-quality-switcher">
+					Current video resolution:
 					<b>
-						<a href="/watch?v=@Model.Player.Player?.Details.Id&q=@f.Itag">@f.QualityLabel</a>
+						@Model.Player.GetPreferredFormat()?.QualityLabel
 					</b>
-				}
-			</div>
-		</noscript>
+					Switch to
+					@foreach (Format f in Model.Player.Player?.Formats?.Where(x => x.Itag != Model.Player.GetFirstItag()) ?? Array.Empty<Format>())
+					{
+						<b>
+							<a href="/watch?v=@Model.Player.Player?.Details.Id&q=@f.Itag">@f.QualityLabel</a>
+						</b>
+					}
+				</div>
+			</noscript>
+		}
 	</div>
 	<div class="info-container">
 		<div class="ml-2 title">


### PR DESCRIPTION
# Details
Fixes livestream pages not loading because of the no-js-quality-switcher-thing. Also fills the thumbnail field in the API.

# Related issues/PRs
Closes #52, Closes #53

# Changes proposed
* Fix livestreams. Again
* Put thumbnails in LightTube playlists in the API