### PR TITLE
Bump InnerTube version & Fix #73

### DIFF
--- a/LightTube/ApiModels/ApiPlaylist.cs
+++ b/LightTube/ApiModels/ApiPlaylist.cs
@@ -17,7 +17,7 @@ public class ApiPlaylist
 	public string LastUpdated { get; }
 	public string VideoCountText { get; }
 	public string ViewCountText { get; }
-	public string? Continuation { get; }
+	public PlaylistContinuationInfo? Continuation { get; }
 	public IEnumerable<PlaylistVideoRenderer> Videos { get; }
 
 	public ApiPlaylist(InnerTubePlaylist playlist)
@@ -48,7 +48,7 @@ public class ApiPlaylist
 		LastUpdated = "";
 		VideoCountText = "";
 		ViewCountText = "";
-		Continuation = playlist.Continuation;
+		Continuation = playlist.Continuation is not null ? InnerTube.Utils.UnpackPlaylistContinuation(playlist.Continuation) : null;
 		Videos = playlist.Contents.Cast<PlaylistVideoRenderer>();
 	}
 

--- a/LightTube/ApiModels/ApiSearchResults.cs
+++ b/LightTube/ApiModels/ApiSearchResults.cs
@@ -9,7 +9,6 @@ public class ApiSearchResults
 	public long? EstimatedResultCount { get; }
 	public SearchParams? SearchParams { get; }
 	public string? ContinuationKey { get; }
-	public InnerTubeSearchResults.TypoFixer? TypoFixer { get; }
 
 	public ApiSearchResults(InnerTubeSearchResults results, SearchParams searchParams)
 	{
@@ -17,7 +16,6 @@ public class ApiSearchResults
 		SearchResults = results.Results;
 		ContinuationKey = results.Continuation;
 		EstimatedResultCount = results.EstimatedResults;
-		TypoFixer = results.DidYouMean;
 	}
 
 	public ApiSearchResults(InnerTubeContinuationResponse continuationResults)
@@ -25,6 +23,5 @@ public class ApiSearchResults
 		SearchResults = continuationResults.Contents;
 		ContinuationKey = continuationResults.Continuation;
 		EstimatedResultCount = null;
-		TypoFixer = null;
 	}
 }

--- a/LightTube/Contexts/PlaylistContext.cs
+++ b/LightTube/Contexts/PlaylistContext.cs
@@ -17,7 +17,7 @@ public class PlaylistContext : BaseContext
 	public string LastUpdatedText;
 	public bool Editable;
 	public IEnumerable<IRenderer> Items;
-	public string? Continuation;
+	public int? Continuation;
 
 	public PlaylistContext(HttpContext context, InnerTubePlaylist playlist) : base(context)
 	{
@@ -31,18 +31,22 @@ public class PlaylistContext : BaseContext
 		LastUpdatedText = playlist.Sidebar.LastUpdated;
 		Editable = false;
 		Items = playlist.Videos;
-		Continuation = playlist.Continuation;
+		Continuation = playlist.Continuation?.ContinueFrom;
 
 		AddMeta("description", playlist.Sidebar.Description);
 		AddMeta("author", playlist.Sidebar.Title);
 		AddMeta("og:title", playlist.Sidebar.Title);
 		AddMeta("og:description", playlist.Sidebar.Description);
-		AddMeta("og:url", $"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
-		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
-		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:image",
+			$"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
+		AddMeta("twitter:card",
+			$"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
 	}
 
-	public PlaylistContext(HttpContext context, InnerTubePlaylist playlist, InnerTubeContinuationResponse continuation) : base(context)
+	public PlaylistContext(HttpContext context, InnerTubePlaylist playlist, InnerTubeContinuationResponse continuation)
+		: base(context)
 	{
 		Id = playlist.Id;
 		PlaylistThumbnail = playlist.Sidebar.Thumbnails.Last().Url.ToString();
@@ -54,15 +58,20 @@ public class PlaylistContext : BaseContext
 		LastUpdatedText = playlist.Sidebar.LastUpdated;
 		Editable = false;
 		Items = continuation.Contents;
-		Continuation = continuation.Continuation;
+		Continuation = continuation.Continuation is not null
+			? InnerTube.Utils.UnpackPlaylistContinuation(continuation.Continuation).ContinueFrom
+			: null;
 
 		AddMeta("description", playlist.Sidebar.Description);
 		AddMeta("author", playlist.Sidebar.Title);
 		AddMeta("og:title", playlist.Sidebar.Title);
 		AddMeta("og:description", playlist.Sidebar.Description);
-		AddMeta("og:url", $"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
-		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
-		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:image",
+			$"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
+		AddMeta("twitter:card",
+			$"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{playlist.Videos.First().Id}/-1");
 	}
 
 	public PlaylistContext(HttpContext context, DatabasePlaylist? playlist) : base(context)
@@ -70,7 +79,7 @@ public class PlaylistContext : BaseContext
 		bool visible = (playlist?.Visibility == PlaylistVisibility.PRIVATE)
 			? User != null && User.UserID == playlist.Author
 			: true;
-		
+
 		if (visible && playlist != null)
 		{
 			Id = playlist.Id;

--- a/LightTube/Controllers/YoutubeController.cs
+++ b/LightTube/Controllers/YoutubeController.cs
@@ -203,7 +203,7 @@ public class YoutubeController : Controller
 	}
 
 	[Route("/playlist")]
-	public async Task<IActionResult> Playlist(string list, string? continuation = null)
+	public async Task<IActionResult> Playlist(string list, int? skip = null)
 	{
 		if (list.StartsWith("LT-PL"))
 		{
@@ -214,14 +214,14 @@ public class YoutubeController : Controller
 		{
 			InnerTubePlaylist playlist =
 				await _youtube.GetPlaylistAsync(list, true, HttpContext.GetLanguage(), HttpContext.GetRegion());
-			if (continuation is null)
+			if (skip is null)
 			{
 				return View(new PlaylistContext(HttpContext, playlist));
 			}
 			else
 			{
 				InnerTubeContinuationResponse continuationRes =
-					await _youtube.ContinuePlaylistAsync(continuation, HttpContext.GetLanguage(),
+					await _youtube.ContinuePlaylistAsync(list, skip.Value, HttpContext.GetLanguage(),
 						HttpContext.GetRegion());
 				return View(new PlaylistContext(HttpContext, playlist, continuationRes));
 			}

--- a/LightTube/Database/Models/DatabasePlaylist.cs
+++ b/LightTube/Database/Models/DatabasePlaylist.cs
@@ -20,10 +20,10 @@ public class DatabasePlaylist
 	{
 		string json = INNERTUBE_PLAYLIST_INFO_TEMPLATE
 			.Replace("%%PLAYLIST_ID%%", Id)
-			.Replace("%%TITLE%%", Name)
+			.Replace("%%TITLE%%", Name.Replace("\"", "\\\""))
 			.Replace("%%VIDEO_COUNT%%", VideoIds.Count.ToString())
 			.Replace("%%CURRENT_INDEX%%", VideoIds.IndexOf(currentVideoId).ToString())
-			.Replace("%%CHANNEL_TITLE%%", Author)
+			.Replace("%%CHANNEL_TITLE%%", Author.Replace("\"", "\\\""))
 			.Replace("%%CHANNEL_ID%%", DatabaseManager.Users.GetUserFromId(Author).Result?.LTChannelID)
 			.Replace("%%CONTENTS%%", DatabaseManager.Playlists.GetPlaylistPanelVideosJson(Id, currentVideoId));
 		return new InnerTubePlaylistInfo(JObject.Parse(json));

--- a/LightTube/Database/Models/DatabaseVideo.cs
+++ b/LightTube/Database/Models/DatabaseVideo.cs
@@ -26,7 +26,7 @@ public class DatabaseVideo
 		Thumbnails = new Thumbnail[] {
 			new()
 			{
-				Url = new Uri($"https://i.ytimg.com/vi/{player.Details.Id}/hqdefault.jpg")
+				Url = player.Details.Thumbnails[0].Url
 			}
 		};
 		UploadedAt = "";

--- a/LightTube/Database/PlaylistManager.cs
+++ b/LightTube/Database/PlaylistManager.cs
@@ -43,12 +43,12 @@ public class PlaylistManager
 			string json = INNERTUBE_PLAYLIST_VIDEO_RENDERER_TEMPLATE
 				.Replace("%%ID%%", editable ? videoId + "!": videoId)
 				.Replace("%%INDEX%%", (i + 1).ToString())
-				.Replace("%%TITLE%%", video?.Title ?? "Uncached video. Click to fix")
+				.Replace("%%TITLE%%", video?.Title.Replace("\"", "\\\"") ?? "Uncached video. Click to fix")
 				.Replace("%%THUMBNAIL%%", video?.Thumbnails.LastOrDefault()?.Url.ToString() ?? "https://i.ytimg.com/vi//hqdefault.jpg")
 				.Replace("%%DURATION%%", video?.Duration ?? "00:00")
 				.Replace("%%DURATION_SECONDS%%", InnerTube.Utils.ParseDuration(video?.Duration ?? "00:00").TotalSeconds.ToString())
 				.Replace("%%UPLADED_AT%%", video?.UploadedAt ?? "???")
-				.Replace("%%CHANNEL_TITLE%%", video?.Channel.Name ?? "???")
+				.Replace("%%CHANNEL_TITLE%%", video?.Channel.Name.Replace("\"", "\\\"") ?? "???")
 				.Replace("%%CHANNEL_ID%%", video?.Channel.Id ?? "???")
 				.Replace("%%VIEWS%%", (video?.Views ?? 0).ToString());
 			renderers.Add(new PlaylistVideoRenderer(JObject.Parse(json)));
@@ -72,10 +72,10 @@ public class PlaylistManager
 				.Replace("%%ID%%", videoId)
 				.Replace("%%SELECTED%%", (currentVideoId == videoId).ToString().ToLower())
 				.Replace("%%INDEX%%", currentVideoId == videoId ? ">" : (i + 1).ToString())
-				.Replace("%%TITLE%%", video?.Title ?? "Uncached video. Click to fix")
+				.Replace("%%TITLE%%", video?.Title.Replace("\"", "\\\"") ?? "Uncached video. Click to fix")
 				.Replace("%%THUMBNAIL%%", video?.Thumbnails.LastOrDefault()?.Url.ToString() ?? "https://i.ytimg.com/vi//hqdefault.jpg")
 				.Replace("%%DURATION%%", video?.Duration ?? "00:00")
-				.Replace("%%CHANNEL_TITLE%%", video?.Channel.Name ?? "???")
+				.Replace("%%CHANNEL_TITLE%%", video?.Channel.Name.Replace("\"", "\\\"") ?? "???")
 				.Replace("%%CHANNEL_ID%%", video?.Channel.Id ?? "???");
 			renderers.Add(new PlaylistPanelVideoRenderer(JObject.Parse(json)));
 		}
@@ -98,10 +98,10 @@ public class PlaylistManager
 				.Replace("%%ID%%", videoId)
 				.Replace("%%SELECTED%%", (currentVideoId == videoId).ToString().ToLower())
 				.Replace("%%INDEX%%", currentVideoId == videoId ? "▶" : (i + 1).ToString())
-				.Replace("%%TITLE%%", video?.Title ?? "Uncached video. Click to fix")
+				.Replace("%%TITLE%%", video?.Title.Replace("\"", "\\\"") ?? "Uncached video. Click to fix")
 				.Replace("%%THUMBNAIL%%", video?.Thumbnails.LastOrDefault()?.Url.ToString() ?? "https://i.ytimg.com/vi//hqdefault.jpg")
 				.Replace("%%DURATION%%", video?.Duration ?? "00:00")
-				.Replace("%%CHANNEL_TITLE%%", video?.Channel.Name ?? "???")
+				.Replace("%%CHANNEL_TITLE%%", video?.Channel.Name.Replace("\"", "\\\"") ?? "???")
 				.Replace("%%CHANNEL_ID%%", video?.Channel.Id ?? "???");
 			renderers.Add(json);
 		}

--- a/LightTube/LightTube.csproj
+++ b/LightTube/LightTube.csproj
@@ -9,7 +9,7 @@
     <ItemGroup>
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
-        <PackageReference Include="InnerTube" Version="1.0.21" /> 
+        <PackageReference Include="InnerTube" Version="1.0.22" /> 
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.8" />
         <PackageReference Include="MongoDB.Driver" Version="2.18.0" />
         <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />

--- a/LightTube/Utils.cs
+++ b/LightTube/Utils.cs
@@ -359,6 +359,16 @@ public static class Utils
 		return $"{parts[0]}?{query.AllKeys.Select(x => x + "=" + query.Get(x)).Aggregate((a, b) => $"{a}&{b}")}";
 	}
 
+	public static string GetSkipUrl(string currentPath, int skipAmount)
+	{
+		string[] parts = currentPath.Split("?");
+		NameValueCollection query = parts.Length > 1
+			? HttpUtility.ParseQueryString(parts[1])
+			: new NameValueCollection();
+		query.Set("skip", skipAmount.ToString());
+		return $"{parts[0]}?{query.AllKeys.Select(x => x + "=" + query.Get(x)).Aggregate((a, b) => $"{a}&{b}")}";
+	}
+
 	public static SubscriptionType GetSubscriptionType(this HttpContext context, string? channelId)
 	{
 		if (channelId is null) return SubscriptionType.NONE;

--- a/LightTube/Views/Youtube/Playlist.cshtml
+++ b/LightTube/Views/Youtube/Playlist.cshtml
@@ -1,4 +1,5 @@
 ﻿@using InnerTube.Renderers
+@using Microsoft.AspNetCore.Http.Extensions
 @model PlaylistContext
 
 @{
@@ -45,7 +46,7 @@
 	<span>•</span>
 	@if (Model.Continuation is not null)
 	{
-		<a href="@Utils.GetContinuationUrl(Context.Request.Path, Model.Continuation)">Next Page</a>
+		<a href="@Utils.GetSkipUrl(Context.Request.GetEncodedPathAndQuery(), Model.Continuation.Value)">Next Page</a>
 	}
 	else
 	{

--- a/LightTube/Views/Youtube/Watch.cshtml
+++ b/LightTube/Views/Youtube/Watch.cshtml
@@ -56,16 +56,19 @@
 					</div>
 				</div>
 			</div>
-			<div class="interaction-buttons hide-on-desktop">
-				<label class="interaction-button" for="comments-toggle">
-					<svg class="icon" width="20" height="20" fill="currentColor">
-						<use xlink:href="/svg/bootstrap-icons.svg#chat-left-text"></use>
-					</svg>
-					<div class="interaction-button__text">
-						Comments
-					</div>
-				</label>
-			</div>
+			@if (Model.Comments is not null)
+			{
+				<div class="interaction-buttons hide-on-desktop">
+					<label class="interaction-button" for="comments-toggle">
+						<svg class="icon" width="20" height="20" fill="currentColor">
+							<use xlink:href="/svg/bootstrap-icons.svg#chat-left-text"></use>
+						</svg>
+						<div class="interaction-button__text">
+							Comments
+						</div>
+					</label>
+				</div>
+			}
 			<div class="interaction-buttons">
 				<a class="interaction-button" href="/addToPlaylist?v=@Model.Video.Id" target="_blank">
 					<svg class="icon" width="20" height="20" fill="currentColor">
@@ -113,34 +116,34 @@
 		</details>
 	</div>
 	<div class="comments-container">
-		<details>
-			<summary>
-				<svg class="icon hide-on-desktop" width="32" height="32" fill="currentColor">
-					<use class="only-when-closed" xlink:href="/svg/bootstrap-icons.svg#chevron-right"></use>
-					<use class="only-when-open" xlink:href="/svg/bootstrap-icons.svg#chevron-down"></use>
-				</svg>
-				@Model.Video.CommentCount comments
-				<div class="flex-divider hide-on-desktop"></div>
-				<label for="comments-toggle" class="hide-on-desktop">
-					<svg class="icon" width="32" height="32" fill="currentColor">
-						<use xlink:href="/svg/bootstrap-icons.svg#x"></use>
+		@if (Model.Comments is not null)
+		{
+			<details>
+				<summary>
+					<svg class="icon hide-on-desktop" width="32" height="32" fill="currentColor">
+						<use class="only-when-closed" xlink:href="/svg/bootstrap-icons.svg#chevron-right"></use>
+						<use class="only-when-open" xlink:href="/svg/bootstrap-icons.svg#chevron-down"></use>
 					</svg>
-				</label>
-			</summary>
-			<div class="comments-container__flex">
-				@if (Model.Comments is not null)
-				{
+					@Model.Video.CommentCount comments
+					<div class="flex-divider hide-on-desktop"></div>
+					<label for="comments-toggle" class="hide-on-desktop">
+						<svg class="icon" width="32" height="32" fill="currentColor">
+							<use xlink:href="/svg/bootstrap-icons.svg#x"></use>
+						</svg>
+					</label>
+				</summary>
+				<div class="comments-container__flex">
 					@foreach (IRenderer renderer in Model.Comments.Contents)
 					{
 						<partial name="Renderer" model="renderer"/>
 					}
-				}
-				else
-				{
-					@:Comments are disabled
-				}
-			</div>
-		</details>
+				</div>
+			</details>
+		}
+		else
+		{
+			@:Comments are disabled
+		}
 	</div>
 	<div class="second-column">
 		@if (Model.Playlist is not null)


### PR DESCRIPTION
# Details
Bumps InnerTube version, and fixes LightTube playlists failing to load because of non-escaped video/channel titles

# Related issues/PRs
Fixes #73 

# Changes proposed
* Make playlists work with the new protobuf continuation
* Fix #73 by escaping strings 
* Hide the comments dropdown & button if they're disabled
* Use thumbnails received from YouTube in DatabaseVideo ctor