### PR TITLE
Add GitHub Actions workflow for building R2R binaries and publishing to Releases

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -49,53 +49,53 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: win-x86 R2R Binaries
-        path: /bin/Release/*/win-x86/publish/
+        path: '*/bin/Release/*/win-x86/publish/'
 
     - name: Upload win-x64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: win-x64 R2R Binaries
-        path: /bin/Release/*/win-x64/publish/
+        path: '*/bin/Release/*/win-x64/publish/'
 
     - name: Upload win-arm64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: win-arm64 R2R Binaries
-        path: /bin/Release/*/win-arm64/publish/
+        path: '*/bin/Release/*/win-arm64/publish/'
 
     - name: Upload linux-x64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: linux-x64 R2R Binaries
-        path: /bin/Release/*/linux-x64/publish/
+        path: '*/bin/Release/*/linux-x64/publish/'
 
     - name: Upload linux-musl-x64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: linux-musl-x64 R2R Binaries
-        path: /bin/Release/*/linux-musl-x64/publish/
+        path: '*/bin/Release/*/linux-musl-x64/publish/'
 
     - name: Upload linux-arm R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: linux-arm R2R Binaries
-        path: /bin/Release/*/linux-arm/publish/
+        path: '*/bin/Release/*/linux-arm/publish/'
 
     - name: Upload linux-arm64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: linux-arm64 R2R Binaries
-        path: /bin/Release/*/linux-arm64/publish/
+        path: '*/bin/Release/*/linux-arm64/publish/'
 
     - name: Upload osx-x64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: osx-x64 R2R Binaries
-        path: /bin/Release/*/osx-x64/publish/
+        path: '*/bin/Release/*/osx-x64/publish/'
 
     - name: Upload osx.11.0-arm64 R2R binaries
       uses: actions/upload-artifact@v3
       with:
         name: osx.11.0-arm64 R2R Binaries
-        path: /bin/Release/*/osx.11.0-arm64/publish/
+        path: '*/bin/Release/*/osx.11.0-arm64/publish/'
       

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -157,7 +157,7 @@ jobs:
         # When skipIfReleaseExists is enabled the action will be skipped if a non-draft release already exists for the provided tag.
         # skipIfReleaseExists: true # optional, default is false
         # An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
-        tag: ${{github.sha}} # optional, default is 
+        tag: prerelease-r2r-${{github.sha}} # optional, default is 
         # The Github token.
         token: ${{secrets.RELEASE_TOKEN}} # optional, default is ${{ github.token }}
         # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -40,8 +40,6 @@ jobs:
       run: dotnet publish -c Release -r linux-arm -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
     - name: Publish linux-arm64
       run: dotnet publish -c Release -r linux-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish linux-bionic-arm64
-      run: dotnet publish -c Release -r linux-bionic-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
     - name: Publish osx-x64
       run: dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
     - name: Publish osx.11.0-arm64
@@ -88,12 +86,6 @@ jobs:
       with:
         name: linux-arm64 R2R Binaries
         path: /bin/Release/*/linux-arm64/publish/
-
-    - name: Upload linux-bionic-arm64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-bionic-arm64 R2R Binaries
-        path: /bin/Release/*/linux-bionic-arm64/publish/
 
     - name: Upload osx-x64 R2R binaries
       uses: actions/upload-artifact@v3

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -1,0 +1,109 @@
+# This workflow will build a .NET project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
+
+name: .NET
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: windows-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: 6.0.x
+    - name: Restore dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --no-restore
+    - name: Test
+      run: dotnet test --no-build --verbosity normal
+    - name: Publish win-x86
+      run: dotnet publish -c Release -r win-x86 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish win-x64
+      run: dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish win-arm64
+      run: dotnet publish -c Release -r win-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish linux-x64
+      run: dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish linux-musl-x64
+      run: dotnet publish -c Release -r linux-musl-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish linux-arm
+      run: dotnet publish -c Release -r linux-arm -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish linux-arm64
+      run: dotnet publish -c Release -r linux-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish linux-bionic-arm64
+      run: dotnet publish -c Release -r linux-bionic-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish osx-x64
+      run: dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish osx.11.0-arm64
+      run: dotnet publish -c Release -r osx.11.0-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+
+    - name: Upload win-x86 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: win-x86 R2R Binaries
+        path: /bin/Release/*/win-x86/publish/
+
+    - name: Upload win-x64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: win-x64 R2R Binaries
+        path: /bin/Release/*/win-x64/publish/
+
+    - name: Upload win-arm64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: win-arm64 R2R Binaries
+        path: /bin/Release/*/win-arm64/publish/
+
+    - name: Upload linux-x64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-x64 R2R Binaries
+        path: /bin/Release/*/linux-x64/publish/
+
+    - name: Upload linux-musl-x64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-musl-x64 R2R Binaries
+        path: /bin/Release/*/linux-musl-x64/publish/
+
+    - name: Upload linux-arm R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-arm R2R Binaries
+        path: /bin/Release/*/linux-arm/publish/
+
+    - name: Upload linux-arm64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-arm64 R2R Binaries
+        path: /bin/Release/*/linux-arm64/publish/
+
+    - name: Upload linux-bionic-arm64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: linux-bionic-arm64 R2R Binaries
+        path: /bin/Release/*/linux-bionic-arm64/publish/
+
+    - name: Upload osx-x64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: osx-x64 R2R Binaries
+        path: /bin/Release/*/osx-x64/publish/
+
+    - name: Upload osx.11.0-arm64 R2R binaries
+      uses: actions/upload-artifact@v3
+      with:
+        name: osx.11.0-arm64 R2R Binaries
+        path: /bin/Release/*/osx.11.0-arm64/publish/
+      

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,19 @@ on:
 
 jobs:
   build:
+    strategy:
+      matrix:
+        platform:
+          - win-x86
+          - win-x64
+          - win-arm64
+          - linux-x64
+          - linux-musl-x64
+          - linux-arm
+          - linux-arm64
+          - osx-x64
+          - osx.11.0-arm64
+
     if: |
       !contains(github.event.head_commit.message, 'skip ci')
 
@@ -28,78 +41,14 @@ jobs:
       run: dotnet build --no-restore
     - name: Test
       run: dotnet test --no-build --verbosity normal
-    - name: Publish win-x86
-      run: dotnet publish -c Release -r win-x86 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish win-x64
-      run: dotnet publish -c Release -r win-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish win-arm64
-      run: dotnet publish -c Release -r win-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish linux-x64
-      run: dotnet publish -c Release -r linux-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish linux-musl-x64
-      run: dotnet publish -c Release -r linux-musl-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish linux-arm
-      run: dotnet publish -c Release -r linux-arm -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish linux-arm64
-      run: dotnet publish -c Release -r linux-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish osx-x64
-      run: dotnet publish -c Release -r osx-x64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
-    - name: Publish osx.11.0-arm64
-      run: dotnet publish -c Release -r osx.11.0-arm64 -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
+    - name: Publish
+      run: dotnet publish -c Release -r ${{ matrix.platform }} -p:PublishSingleFile=true -p:PublishReadyToRun=true -p:PublishReadyToRunShowWarnings=true -p:PublishTrimmed=true -p:TrimMode=partial --self-contained true
 
-    - name: Upload win-x86 R2R binaries
+    - name: Upload binaries
       uses: actions/upload-artifact@v3
       with:
-        name: win-x86 R2R Binaries
-        path: '*/bin/Release/*/win-x86/publish/'
-
-    - name: Upload win-x64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: win-x64 R2R Binaries
-        path: '*/bin/Release/*/win-x64/publish/'
-
-    - name: Upload win-arm64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: win-arm64 R2R Binaries
-        path: '*/bin/Release/*/win-arm64/publish/'
-
-    - name: Upload linux-x64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-x64 R2R Binaries
-        path: '*/bin/Release/*/linux-x64/publish/'
-
-    - name: Upload linux-musl-x64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-musl-x64 R2R Binaries
-        path: '*/bin/Release/*/linux-musl-x64/publish/'
-
-    - name: Upload linux-arm R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-arm R2R Binaries
-        path: '*/bin/Release/*/linux-arm/publish/'
-
-    - name: Upload linux-arm64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: linux-arm64 R2R Binaries
-        path: '*/bin/Release/*/linux-arm64/publish/'
-
-    - name: Upload osx-x64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: osx-x64 R2R Binaries
-        path: '*/bin/Release/*/osx-x64/publish/'
-
-    - name: Upload osx.11.0-arm64 R2R binaries
-      uses: actions/upload-artifact@v3
-      with:
-        name: osx.11.0-arm64 R2R Binaries
-        path: '*/bin/Release/*/osx.11.0-arm64/publish/'
+        name: ${{ matrix.platform }} R2R Binaries
+        path: '*/bin/Release/*/${{ matrix.platform }}/publish/'
 
     - name: Create Release
       # You may pin to the exact commit or the version.
@@ -113,7 +62,7 @@ jobs:
         # An optional flag which indicates if artifact read or upload errors should fail the build.
         artifactErrorsFailBuild: false # optional, default is 
         # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
-        artifact: '**'
+        artifacts	: ${{ matrix.platform }} R2R Binaries.zip
         # The content type of the artifact. Defaults to raw
         artifactContentType: raw # optional, default is 
         # An optional body for the release.

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -11,6 +11,8 @@ on:
 
 jobs:
   build:
+    if: |
+      !contains(github.event.head_commit.message, 'skip ci')
 
     runs-on: windows-latest
 
@@ -98,4 +100,65 @@ jobs:
       with:
         name: osx.11.0-arm64 R2R Binaries
         path: '*/bin/Release/*/osx.11.0-arm64/publish/'
-      
+
+    - name: Create Release
+      # You may pin to the exact commit or the version.
+      # uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
+      uses: ncipollo/release-action@v1.12.0
+      if: |
+        github.event_name == 'push'
+      with:
+        # An optional flag which indicates if we should update a release if it already exists. Defaults to false.
+        allowUpdates: true # optional, default is 
+        # An optional flag which indicates if artifact read or upload errors should fail the build.
+        artifactErrorsFailBuild: false # optional, default is 
+        # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
+        artifact: '**'
+        # The content type of the artifact. Defaults to raw
+        artifactContentType: raw # optional, default is 
+        # An optional body for the release.
+        # body: # optional, default is 
+        # An optional body file for the release. This should be the path to the file
+        # bodyFile: # optional, default is 
+        # An optional commit reference. This will be used to create the tag if it does not exist.
+        commit: ${{github.sha}} # optional, default is 
+        # When provided this will generate a discussion of the specified category. The category must exist otherwise this will cause the action to fail. This isn't used with draft releases
+        # discussionCategory: # optional, default is 
+        # Optionally marks this release as a draft release. Set to true to enable.
+        draft: false # optional, default is 
+        # Indicates if release notes should be automatically generated.
+        generateReleaseNotes: true # optional, default is false
+        # Indicates if the release should be the "latest" release or not.
+        makeLatest: true # optional, default is legacy
+        # An optional name for the release. If this is omitted the tag will be used.
+        name: Rolling R2R Build for commit ${{github.sha}} # optional, default is 
+        ## Indicates if the release body should be omitted.
+        #omitBody: # optional, default is false
+        ## Indicates if the release body should be omitted during updates. The body will still be applied for newly created releases. This will preserve the existing body during updates.
+        #omitBodyDuringUpdate: # optional, default is false
+        ## Indicates if the draft flag should be omitted during updates. The draft flag will still be applied for newly created releases. This will preserve the existing draft state during updates.
+        #omitDraftDuringUpdate: # optional, default is false
+        ## Indicates if the release name should be omitted.
+        #omitName: # optional, default is false
+        ## Indicates if the release name should be omitted during updates. The name will still be applied for newly created releases. This will preserve the existing name during updates.
+        #omitNameDuringUpdate: # optional, default is false
+        ## Indicates if the prerelease flag should be omitted during updates. The prerelease flag will still be applied for newly created releases. This will preserve the existing prerelease state during updates.
+        #omitPrereleaseDuringUpdate: # optional, default is false
+        # Optionally specify the owner of the repo where the release should be generated. Defaults to current repo's owner.
+        # owner: # optional, default is 
+        # Optionally marks this release as prerelease. Set to true to enable.
+        prerelease: true # optional, default is 
+        # Indicates if existing release artifacts should be removed, Defaults to false.
+        removeArtifacts: false # optional, default is false
+        # Indicates if existing release artifacts should be replaced. Defaults to true.
+        replacesArtifacts: true # optional, default is true
+        # Optionally specify the repo where the release should be generated. Defaults to current repo
+        # repo: # optional, default is 
+        # When skipIfReleaseExists is enabled the action will be skipped if a non-draft release already exists for the provided tag.
+        # skipIfReleaseExists: true # optional, default is false
+        # An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
+        tag: ${{github.sha}} # optional, default is 
+        # The Github token.
+        # token: # optional, default is ${{ github.token }}
+        # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.
+        # updateOnlyUnreleased: # optional, default is false

--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -159,6 +159,6 @@ jobs:
         # An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
         tag: ${{github.sha}} # optional, default is 
         # The Github token.
-        # token: # optional, default is ${{ github.token }}
+        token: ${{secrets.RELEASE_TOKEN}} # optional, default is ${{ github.token }}
         # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.
         # updateOnlyUnreleased: # optional, default is false

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -3,11 +3,7 @@
 
 name: .NET R2R Build
 
-on:
-  push:
-    branches: [ "master" ]
-  pull_request:
-    branches: [ "master" ]
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -63,29 +63,29 @@ jobs:
         github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
         # An optional flag which indicates if we should update a release if it already exists. Defaults to false.
-        allowUpdates: true # optional, default is 
+        allowUpdates: true # optional, default is
         # An optional flag which indicates if artifact read or upload errors should fail the build.
-        artifactErrorsFailBuild: false # optional, default is 
+        artifactErrorsFailBuild: false # optional, default is
         # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
         artifacts: ${{ matrix.platform }} R2R Binaries.zip
         # The content type of the artifact. Defaults to raw
-        artifactContentType: raw # optional, default is 
+        artifactContentType: raw # optional, default is
         # An optional body for the release.
-        # body: # optional, default is 
+        # body: # optional, default is
         # An optional body file for the release. This should be the path to the file
-        # bodyFile: # optional, default is 
+        # bodyFile: # optional, default is
         # An optional commit reference. This will be used to create the tag if it does not exist.
-        commit: ${{github.sha}} # optional, default is 
+        commit: ${{github.sha}} # optional, default is
         # When provided this will generate a discussion of the specified category. The category must exist otherwise this will cause the action to fail. This isn't used with draft releases
-        # discussionCategory: # optional, default is 
+        # discussionCategory: # optional, default is
         # Optionally marks this release as a draft release. Set to true to enable.
-        draft: false # optional, default is 
+        draft: false # optional, default is
         # Indicates if release notes should be automatically generated.
         generateReleaseNotes: true # optional, default is false
         # Indicates if the release should be the "latest" release or not.
         makeLatest: true # optional, default is legacy
         # An optional name for the release. If this is omitted the tag will be used.
-        name: Rolling R2R Build for commit `${{steps.sha.outputs.substring}}` # optional, default is 
+        name: Rolling R2R Build for commit `${{steps.sha.outputs.substring}}` # optional, default is
         ## Indicates if the release body should be omitted.
         #omitBody: # optional, default is false
         ## Indicates if the release body should be omitted during updates. The body will still be applied for newly created releases. This will preserve the existing body during updates.
@@ -99,19 +99,19 @@ jobs:
         ## Indicates if the prerelease flag should be omitted during updates. The prerelease flag will still be applied for newly created releases. This will preserve the existing prerelease state during updates.
         #omitPrereleaseDuringUpdate: # optional, default is false
         # Optionally specify the owner of the repo where the release should be generated. Defaults to current repo's owner.
-        # owner: # optional, default is 
+        # owner: # optional, default is
         # Optionally marks this release as prerelease. Set to true to enable.
-        prerelease: true # optional, default is 
+        prerelease: true # optional, default is
         # Indicates if existing release artifacts should be removed, Defaults to false.
         removeArtifacts: false # optional, default is false
         # Indicates if existing release artifacts should be replaced. Defaults to true.
         replacesArtifacts: true # optional, default is true
         # Optionally specify the repo where the release should be generated. Defaults to current repo
-        # repo: # optional, default is 
+        # repo: # optional, default is
         # When skipIfReleaseExists is enabled the action will be skipped if a non-draft release already exists for the provided tag.
         # skipIfReleaseExists: true # optional, default is false
         # An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
-        tag: prerelease-r2r-${{steps.sha.outputs.substring}}-${{github.run_id}} # optional, default is 
+        tag: prerelease-r2r-${{steps.sha.outputs.substring}}-${{github.run_id}} # optional, default is
         # The Github token.
         token: ${{secrets.RELEASE_TOKEN}} # optional, default is ${{ github.token }}
         # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -50,9 +50,8 @@ jobs:
         name: ${{ matrix.platform }} R2R Binaries
         path: '*/bin/Release/*/${{ matrix.platform }}/publish/'
 
-    - uses: edgarrc/action-7z@v1
-      with:
-        args: '7z a "${{ matrix.platform }} R2R Binaries.zip" "*/bin/Release/*/${{ matrix.platform }}/publish/"'
+    - name: Pack with 7-zip
+      run: '7z a "${{ matrix.platform }} R2R Binaries.zip" "*/bin/Release/*/${{ matrix.platform }}/publish/"'
 
     - name: Create Release
       # You may pin to the exact commit or the version.

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -1,7 +1,7 @@
 # This workflow will build a .NET project
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-net
 
-name: .NET
+name: .NET R2R Build
 
 on:
   push:
@@ -50,6 +50,10 @@ jobs:
         name: ${{ matrix.platform }} R2R Binaries
         path: '*/bin/Release/*/${{ matrix.platform }}/publish/'
 
+    - uses: edgarrc/action-7z@v1
+      with:
+        args: '7z a "${{ matrix.platform }} R2R Binaries.zip" "*/bin/Release/*/${{ matrix.platform }}/publish/"'
+
     - name: Create Release
       # You may pin to the exact commit or the version.
       # uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
@@ -62,7 +66,7 @@ jobs:
         # An optional flag which indicates if artifact read or upload errors should fail the build.
         artifactErrorsFailBuild: false # optional, default is 
         # An optional set of paths representing artifacts to upload to the release. This may be a single path or a comma delimited list of paths (or globs)
-        artifacts	: ${{ matrix.platform }} R2R Binaries.zip
+        artifacts: ${{ matrix.platform }} R2R Binaries.zip
         # The content type of the artifact. Defaults to raw
         artifactContentType: raw # optional, default is 
         # An optional body for the release.

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -49,8 +49,6 @@ jobs:
     - name: Pack with 7-zip
       run: '7z a "${{ matrix.platform }} R2R Binaries.zip" "*/bin/Release/*/${{ matrix.platform }}/publish/"'
 
-    - run: '$env:SHA_SHORT = $("${{github.sha}}".Substring(0, 6))'
-
     - uses: bhowell2/github-substring-action@1.0.2
       id: sha
       with:

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -51,6 +51,12 @@ jobs:
 
     - run: '$env:SHA_SHORT = $("${{github.sha}}".Substring(0, 6))'
 
+    - uses: bhowell2/github-substring-action@1.0.2
+      id: sha
+      with:
+        value: ${{ github.sha }}
+        length_from_start: 7
+
     - name: Create Release
       # You may pin to the exact commit or the version.
       # uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
@@ -81,7 +87,7 @@ jobs:
         # Indicates if the release should be the "latest" release or not.
         makeLatest: true # optional, default is legacy
         # An optional name for the release. If this is omitted the tag will be used.
-        name: Rolling R2R Build for commit `${{env.SHA_SHORT}}` # optional, default is 
+        name: Rolling R2R Build for commit `${{steps.sha.outputs.substring}}` # optional, default is 
         ## Indicates if the release body should be omitted.
         #omitBody: # optional, default is false
         ## Indicates if the release body should be omitted during updates. The body will still be applied for newly created releases. This will preserve the existing body during updates.
@@ -107,7 +113,7 @@ jobs:
         # When skipIfReleaseExists is enabled the action will be skipped if a non-draft release already exists for the provided tag.
         # skipIfReleaseExists: true # optional, default is false
         # An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
-        tag: prerelease-r2r-${{env.SHA_SHORT}}-${{env.GITHUB_RUN_ID}} # optional, default is 
+        tag: prerelease-r2r-${{steps.sha.outputs.substring}}-${{github.run_id}} # optional, default is 
         # The Github token.
         token: ${{secrets.RELEASE_TOKEN}} # optional, default is ${{ github.token }}
         # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.

--- a/.github/workflows/r2r.yml
+++ b/.github/workflows/r2r.yml
@@ -53,12 +53,14 @@ jobs:
     - name: Pack with 7-zip
       run: '7z a "${{ matrix.platform }} R2R Binaries.zip" "*/bin/Release/*/${{ matrix.platform }}/publish/"'
 
+    - run: '$env:SHA_SHORT = $("${{github.sha}}".Substring(0, 6))'
+
     - name: Create Release
       # You may pin to the exact commit or the version.
       # uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
       uses: ncipollo/release-action@v1.12.0
       if: |
-        github.event_name == 'push'
+        github.event_name == 'push' && github.ref == 'refs/heads/master'
       with:
         # An optional flag which indicates if we should update a release if it already exists. Defaults to false.
         allowUpdates: true # optional, default is 
@@ -83,7 +85,7 @@ jobs:
         # Indicates if the release should be the "latest" release or not.
         makeLatest: true # optional, default is legacy
         # An optional name for the release. If this is omitted the tag will be used.
-        name: Rolling R2R Build for commit ${{github.sha}} # optional, default is 
+        name: Rolling R2R Build for commit `${{env.SHA_SHORT}}` # optional, default is 
         ## Indicates if the release body should be omitted.
         #omitBody: # optional, default is false
         ## Indicates if the release body should be omitted during updates. The body will still be applied for newly created releases. This will preserve the existing body during updates.
@@ -109,7 +111,7 @@ jobs:
         # When skipIfReleaseExists is enabled the action will be skipped if a non-draft release already exists for the provided tag.
         # skipIfReleaseExists: true # optional, default is false
         # An optional tag for the release. If this is omitted the git ref will be used (if it is a tag).
-        tag: prerelease-r2r-${{github.sha}} # optional, default is 
+        tag: prerelease-r2r-${{env.SHA_SHORT}}-${{env.GITHUB_RUN_ID}} # optional, default is 
         # The Github token.
         token: ${{secrets.RELEASE_TOKEN}} # optional, default is ${{ github.token }}
         # When allowUpdates is enabled, this will fail the action if the release it is updating is not a draft or a prerelease.

--- a/LightTube/LightTube.csproj
+++ b/LightTube/LightTube.csproj
@@ -4,6 +4,7 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
+        <PublishReadyToRunExclude Include="ZstdSharp.dll" />
     </PropertyGroup>
 
     <ItemGroup>

--- a/LightTube/LightTube.csproj
+++ b/LightTube/LightTube.csproj
@@ -4,10 +4,10 @@
         <TargetFramework>net6.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
-        <PublishReadyToRunExclude Include="ZstdSharp.dll" />
     </PropertyGroup>
 
     <ItemGroup>
+        <PublishReadyToRunExclude Include="ZstdSharp.dll" />
         <PackageReference Include="BCrypt.Net-Next" Version="4.0.3" />
         <PackageReference Include="Humanizer.Core" Version="2.14.1" />
         <PackageReference Include="InnerTube" Version="1.0.23" /> 

--- a/LightTube/Utils.cs
+++ b/LightTube/Utils.cs
@@ -54,8 +54,7 @@ public static class Utils
 			DateTime buildTime = DateTime.Today;
 			_version = $"{buildTime.Year}.{buildTime.Month}.{buildTime.Day} (dev)";
 #else
-			_version = FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location)
-				.FileVersion?[2..];
+			_version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
 #endif
 		}
 

--- a/LightTube/Utils.cs
+++ b/LightTube/Utils.cs
@@ -54,7 +54,7 @@ public static class Utils
 			DateTime buildTime = DateTime.Today;
 			_version = $"{buildTime.Year}.{buildTime.Month}.{buildTime.Day} (dev)";
 #else
-			_version = Assembly.GetExecutingAssembly().GetName().Version.ToString();
+			_version = Assembly.GetExecutingAssembly().GetName().Version!.ToString();
 #endif
 		}
 


### PR DESCRIPTION
# Details
Adds a GitHub Actions workflow for building [R2R](https://learn.microsoft.com/en-us/dotnet/core/deploying/ready-to-run) binaries and automatically publishing them as prerelease on GitHub Releases (for pushes on master)

# Changes proposed
* Replace FileVersionInfo.GetVersionInfo use with direct assembly version lookup
* Create GH Actions workflow for R2R builds

# Notes
In order to make releases work:
- Create a PAT for this repository with read-write code permissions (via https://github.com/settings/tokens?type=beta)
- Add it as a secret called RELEASE_TOKEN (via https://github.com/kuylar/LightTube/settings/secrets/actions)
Otherwise remove the release section from the workflow or builds will fail.