### PR TITLE
Fix compatibility mode option being ignored

### DIFF
--- a/LightTube/Controllers/SettingsController.cs
+++ b/LightTube/Controllers/SettingsController.cs
@@ -34,7 +34,7 @@ public class SettingsController : Controller
 
 	[Route("appearance")]
 	[HttpPost]
-	public IActionResult Appearance(string hl, string gl, string theme, string recommendations)
+	public IActionResult Appearance(string hl, string gl, string theme, string recommendations, string compatibility)
 	{
 		Response.Cookies.Append("hl", hl, new CookieOptions
 		{
@@ -49,6 +49,10 @@ public class SettingsController : Controller
 			Expires = DateTimeOffset.MaxValue
 		});
 		Response.Cookies.Append("recommendations", recommendations == "on" ? "visible" : "collapsed", new CookieOptions
+		{
+			Expires = DateTimeOffset.MaxValue
+		});
+		Response.Cookies.Append("compatibility", recommendations == "on" ? "true" : "false", new CookieOptions
 		{
 			Expires = DateTimeOffset.MaxValue
 		});

--- a/LightTube/Controllers/YoutubeController.cs
+++ b/LightTube/Controllers/YoutubeController.cs
@@ -45,6 +45,9 @@ public class YoutubeController : Controller
 			sponsors = Array.Empty<SponsorBlockSegment>();
 		}
 
+		if (HttpContext.GetDefaultCompatibility())
+			compatibility = true;
+
 		InnerTubeNextResponse video =
 			await _youtube.GetVideoAsync(v, language: HttpContext.GetLanguage(), region: HttpContext.GetRegion());
 		if (player is null || e is not null)
@@ -74,6 +77,9 @@ public class YoutubeController : Controller
 			await _youtube.GetVideoAsync(v, localPlaylist ? null : list, language: HttpContext.GetLanguage(),
 				region: HttpContext.GetRegion());
 		InnerTubeContinuationResponse? comments = null;
+
+		if (HttpContext.GetDefaultCompatibility())
+			compatibility = true;
 
 		try
 		{

--- a/LightTube/Utils.cs
+++ b/LightTube/Utils.cs
@@ -46,6 +46,11 @@ public static class Utils
 			? recommendations == "visible"
 			: true;
 
+	public static bool GetDefaultCompatibility(this HttpContext context) =>
+		context.Request.Cookies.TryGetValue("compatibility", out string compatibility)
+			? compatibility == "true"
+			: false;
+
 	public static string GetVersion()
 	{
 		if (_version is null)

--- a/LightTube/Views/Settings/Appearance.cshtml
+++ b/LightTube/Views/Settings/Appearance.cshtml
@@ -123,5 +123,26 @@
 		}
 	</div>
 </label>
+
+<label class="settings-option">
+	<div class="settings-option__info">
+		<div class="ml-2 title">
+			Compatibility mode
+		</div>
+		<div>
+			Use MP4 streams instead of HLS streams. Breaks livestreams
+		</div>
+	</div>
+	<div class="settings-option__option">
+		@if (Context.GetDefaultCompatibility())
+		{
+			<input type="checkbox" name="compatibility" checked>
+		}
+		else
+		{
+			<input type="checkbox" name="compatibility">
+		}
+	</div>
+</label>
 <br>
 <input type="submit" class="btn-outline btn-blue" style="width:fit-content;" value="Save Changes">

--- a/LightTube/Views/Shared/Player.cshtml
+++ b/LightTube/Views/Shared/Player.cshtml
@@ -126,7 +126,10 @@ else
 			href: "/channel/@Model.Player!.Details.Author.Id"
 		},
 		title: "@Model.Player!.Details.Title", // .Replace("\"", "\\\"")
-		hlsManifest: "/proxy/media/@(Model.Player.Details.Id).m3u8",
+		@if (Model.UseHls)
+		{
+			@:hlsManifest: "/proxy/media/@(Model.Player.Details.Id).m3u8",
+		}
 		buttons: {
 			play: '<svg class="bi" width="20" height="20" fill="currentColor"><use href="/svg/bootstrap-icons.svg#play-fill"/></svg>',
 			pause: '<svg class="bi" width="20" height="20" fill="currentColor"><use href="/svg/bootstrap-icons.svg#pause-fill"/></svg>',


### PR DESCRIPTION
# Details
Compatibility option would be ignored when setting the video source for LTPlayer

# Changes proposed
* Add a permanent compatibility option in the settings
* Fix the Player.cshtml to respect the compatibility setting
* Fix videos not loading when the video proxy is disabled