### PR TITLE
Fix the OpenGraph tags for better embeds in third party sites

### DIFF
--- a/LightTube/Contexts/EmbedContext.cs
+++ b/LightTube/Contexts/EmbedContext.cs
@@ -11,11 +11,41 @@ public class EmbedContext : BaseContext
 	{
 		Player = new PlayerContext(context, innerTubePlayer, innerTubeNextResponse, "embed", compatibility, context.Request.Query["q"], sponsors);
 		Video = innerTubeNextResponse;
+		
+		AddMeta("description", Video.Description);
+		AddMeta("author", Video.Channel.Title);
+		AddMeta("og:title", Video.Title);
+		AddMeta("og:description", Video.Description);
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("og:video:url", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
+		AddMeta("og:video:width", "640");
+		AddMeta("og:video:height", "360");
+		AddMeta("og:type", "video.other");
+		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/{Video.Id}");
+		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
 	}
 
 	public EmbedContext(HttpContext context, Exception e, InnerTubeNextResponse innerTubeNextResponse) : base(context)
 	{
 		Player = new PlayerContext(context, e);
 		Video = innerTubeNextResponse;
+		
+		AddMeta("description", Video.Description);
+		AddMeta("author", Video.Channel.Title);
+		AddMeta("og:title", Video.Title);
+		AddMeta("og:description", Video.Description);
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("og:video:url", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
+		AddMeta("og:video:width", "640");
+		AddMeta("og:video:height", "360");
+		AddMeta("og:type", "video.other");
+		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/{Video.Id}");
+		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
 	}
 }

--- a/LightTube/Contexts/WatchContext.cs
+++ b/LightTube/Contexts/WatchContext.cs
@@ -12,11 +12,13 @@ public class WatchContext : BaseContext
 	public int Dislikes;
 	public SponsorBlockSegment[] Sponsors;
 
-	public WatchContext(HttpContext context, InnerTubePlayer innerTubePlayer, InnerTubeNextResponse innerTubeNextResponse,
+	public WatchContext(HttpContext context, InnerTubePlayer innerTubePlayer,
+		InnerTubeNextResponse innerTubeNextResponse,
 		InnerTubeContinuationResponse? comments,
 		bool compatibility, int dislikes, SponsorBlockSegment[] sponsors) : base(context)
 	{
-		Player = new PlayerContext(context, innerTubePlayer, innerTubeNextResponse, "embed", compatibility, context.Request.Query["q"], sponsors);
+		Player = new PlayerContext(context, innerTubePlayer, innerTubeNextResponse, "embed", compatibility,
+			context.Request.Query["q"], sponsors);
 		Video = innerTubeNextResponse;
 		Playlist = Video.Playlist;
 		Comments = comments;
@@ -28,11 +30,16 @@ public class WatchContext : BaseContext
 		AddMeta("author", Video.Channel.Title);
 		AddMeta("og:title", Video.Title);
 		AddMeta("og:description", Video.Description);
-		AddMeta("og:url", $"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
 		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("og:video:url", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
+		AddMeta("og:video:width", "640");
+		AddMeta("og:video:height", "360");
+        AddMeta("og:type", "video.other");
 		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
-		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/${Video.Id}");
-		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/${Video.Id}/18");
+		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/{Video.Id}");
+		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
 
 		AddStylesheet("/lib/ltplayer.css");
 
@@ -56,22 +63,29 @@ public class WatchContext : BaseContext
 		AddMeta("author", Video.Channel.Title);
 		AddMeta("og:title", Video.Title);
 		AddMeta("og:description", Video.Description);
-		AddMeta("og:url", $"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
 		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("og:video:url", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
+		AddMeta("og:video:width", "640");
+		AddMeta("og:video:height", "360");
+        AddMeta("og:type", "video.other");
 		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
-		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/${Video.Id}");
-		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/${Video.Id}/18");
+		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/{Video.Id}");
+		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
 	}
 
-	public WatchContext(HttpContext context, InnerTubePlayer innerTubePlayer, InnerTubeNextResponse innerTubeNextResponse, DatabasePlaylist? playlist,
+	public WatchContext(HttpContext context, InnerTubePlayer innerTubePlayer,
+		InnerTubeNextResponse innerTubeNextResponse, DatabasePlaylist? playlist,
 		InnerTubeContinuationResponse? comments,
 		bool compatibility, int dislikes, SponsorBlockSegment[] sponsors) : base(context)
 	{
-		Player = new PlayerContext(context, innerTubePlayer, innerTubeNextResponse, "embed", compatibility, context.Request.Query["q"], sponsors);
+		Player = new PlayerContext(context, innerTubePlayer, innerTubeNextResponse, "embed", compatibility,
+			context.Request.Query["q"], sponsors);
 		Video = innerTubeNextResponse;
 		Playlist = playlist?.GetInnerTubePlaylistInfo(innerTubePlayer.Details.Id);
 		if (playlist != null && playlist.Visibility == PlaylistVisibility.PRIVATE)
-			if (playlist.Author != User?.UserID) 
+			if (playlist.Author != User?.UserID)
 				Playlist = null;
 		Comments = comments;
 		Dislikes = dislikes;
@@ -82,11 +96,16 @@ public class WatchContext : BaseContext
 		AddMeta("author", Video.Channel.Title);
 		AddMeta("og:title", Video.Title);
 		AddMeta("og:description", Video.Description);
-		AddMeta("og:url", $"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
 		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("og:video:url", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
+		AddMeta("og:video:width", "640");
+		AddMeta("og:video:height", "360");
+        AddMeta("og:type", "video.other");
 		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
-		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/${Video.Id}");
-		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/${Video.Id}/18");
+		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/{Video.Id}");
+		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
 
 		AddStylesheet("/lib/ltplayer.css");
 
@@ -95,14 +114,15 @@ public class WatchContext : BaseContext
 		AddScript("/js/player.js");
 	}
 
-	public WatchContext(HttpContext context, Exception e, InnerTubeNextResponse innerTubeNextResponse, DatabasePlaylist? playlist,
+	public WatchContext(HttpContext context, Exception e, InnerTubeNextResponse innerTubeNextResponse,
+		DatabasePlaylist? playlist,
 		InnerTubeContinuationResponse? comments, int dislikes) : base(context)
 	{
 		Player = new PlayerContext(context, e);
 		Video = innerTubeNextResponse;
 		Playlist = playlist?.GetInnerTubePlaylistInfo(innerTubeNextResponse.Id);
 		if (playlist != null && playlist.Visibility == PlaylistVisibility.PRIVATE)
-			if (playlist.Author != User?.UserID) 
+			if (playlist.Author != User?.UserID)
 				Playlist = null;
 		Comments = comments;
 		Dislikes = dislikes;
@@ -113,10 +133,15 @@ public class WatchContext : BaseContext
 		AddMeta("author", Video.Channel.Title);
 		AddMeta("og:title", Video.Title);
 		AddMeta("og:description", Video.Description);
-		AddMeta("og:url", $"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
+		AddMeta("og:url",
+			$"{context.Request.Scheme}://{context.Request.Host}/{context.Request.Path}{context.Request.QueryString}");
 		AddMeta("og:image", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
+		AddMeta("og:video:url", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
+		AddMeta("og:video:width", "640");
+		AddMeta("og:video:height", "360");
+        AddMeta("og:type", "video.other");
 		AddMeta("twitter:card", $"{context.Request.Scheme}://{context.Request.Host}/proxy/thumbnail/{Video.Id}/-1");
-		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/${Video.Id}");
-		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/${Video.Id}/18");
+		AddMeta("twitter:player", $"https://{context.Request.Host}/embed/{Video.Id}");
+		AddMeta("twitter:player:stream", $"https://{context.Request.Host}/proxy/media/{Video.Id}/18.mp4");
 	}
 }

--- a/LightTube/Controllers/MediaController.cs
+++ b/LightTube/Controllers/MediaController.cs
@@ -37,7 +37,8 @@ public class ProxyController : Controller
 	}
 
 	[Route("media/{videoId}/{formatId}")]
-	public async Task Media(string videoId, string formatId, string? audioTrackId)
+	[Route("media/{videoId}/{formatId}.{extension}")]
+	public async Task Media(string videoId, string formatId, string? audioTrackId, string? extension = null)
 	{
 		if (Configuration.GetVariable("LIGHTTUBE_DISABLE_PROXY", "false") != "false")
 		{


### PR DESCRIPTION
# Details
Fixes the OpenGraph tags so we can embed in Discord.

# Changes proposed
* Add a `/proxy/media/{videoId}/{format}.{extension}` route
* Add og:video tags to embed in other sites

# Notes
You will no longer have to type https://<instance>/proxy/media/whatever when you want to directly embed a video!!
