### PR TITLE
Render last 5 videos from user's subscribed chanels (#70)

### DIFF
--- a/LightTube/Contexts/BaseContext.cs
+++ b/LightTube/Contexts/BaseContext.cs
@@ -14,19 +14,11 @@ public class BaseContext
 	public bool GuideHidden = false;
 	public HttpContext Context;
 	public DatabaseUser? User;
-	public FeedVideo[] Videos;
 
 	public BaseContext(HttpContext context)
 	{
 		Context = context;
 		User = DatabaseManager.Users.GetUserFromToken(context.Request.Cookies["token"] ?? "").Result;
-		if (User != null)
-		{
-			Videos = Task.Run(async () =>
-			{
-				return (await YoutubeRSS.GetMultipleFeeds(User.Subscriptions.Keys)).Chunk(5).First();
-			}).Result;
-		}
 		AddMeta("og:site_name", "lighttube");
 		AddMeta("og:type", "website");
 		AddMeta("theme-color", "#AA0000");

--- a/LightTube/Contexts/BaseContext.cs
+++ b/LightTube/Contexts/BaseContext.cs
@@ -14,11 +14,19 @@ public class BaseContext
 	public bool GuideHidden = false;
 	public HttpContext Context;
 	public DatabaseUser? User;
+	public FeedVideo[] Videos;
 
 	public BaseContext(HttpContext context)
 	{
 		Context = context;
 		User = DatabaseManager.Users.GetUserFromToken(context.Request.Cookies["token"] ?? "").Result;
+		if (User != null)
+		{
+			Videos = Task.Run(async () =>
+			{
+				return (await YoutubeRSS.GetMultipleFeeds(User.Subscriptions.Keys)).Chunk(5).First();
+			}).Result;
+		}
 		AddMeta("og:site_name", "lighttube");
 		AddMeta("og:type", "website");
 		AddMeta("theme-color", "#AA0000");

--- a/LightTube/Contexts/HomepageContext.cs
+++ b/LightTube/Contexts/HomepageContext.cs
@@ -11,7 +11,7 @@ namespace LightTube.Contexts
 			{
 				Videos = Task.Run(async () =>
 				{
-					return (await YoutubeRSS.GetMultipleFeeds(User.Subscriptions.Where(x => x.Value == SubscriptionType.NOTIFICATIONS_ON).Select(x => x.Key))).Take(Convert.ToInt32(context.Request.Cookies["maxvideos"])).ToArray();
+					return (await YoutubeRSS.GetMultipleFeeds(User.Subscriptions.Where(x => x.Value == SubscriptionType.NOTIFICATIONS_ON).Select(x => x.Key))).Take(context.Request.Cookies["maxvideos"] is null ? 5:Convert.ToInt32(context.Request.Cookies["maxvideos"])).ToArray();
 				}).Result;
 			}
 		}

--- a/LightTube/Contexts/HomepageContext.cs
+++ b/LightTube/Contexts/HomepageContext.cs
@@ -1,0 +1,19 @@
+﻿using LightTube.Database.Models;
+
+namespace LightTube.Contexts
+{
+	public class HomepageContext : BaseContext
+	{
+		public FeedVideo[] Videos;
+		public HomepageContext(HttpContext context) : base(context)
+		{
+			if (User != null)
+			{
+				Videos = Task.Run(async () =>
+				{
+					return (await YoutubeRSS.GetMultipleFeeds(User.Subscriptions.Where(x => x.Value == SubscriptionType.NOTIFICATIONS_ON).Select(x => x.Key))).Take(Convert.ToInt32(context.Request.Cookies["maxvideos"])).ToArray();
+				}).Result;
+			}
+		}
+	}
+}

--- a/LightTube/Controllers/HomeController.cs
+++ b/LightTube/Controllers/HomeController.cs
@@ -14,7 +14,7 @@ public class HomeController : Controller
 		_logger = logger;
 	}
 
-	public IActionResult Index() => View(new BaseContext(HttpContext));
+	public IActionResult Index() => View(new HomepageContext(HttpContext));
 
 	[Route("/rss")]
 	public IActionResult Rss() => View(new BaseContext(HttpContext));

--- a/LightTube/Controllers/SettingsController.cs
+++ b/LightTube/Controllers/SettingsController.cs
@@ -34,7 +34,7 @@ public class SettingsController : Controller
 
 	[Route("appearance")]
 	[HttpPost]
-	public IActionResult Appearance(string hl, string gl, string theme, string recommendations, string compatibility)
+	public IActionResult Appearance(string hl, string gl, string theme, string recommendations, string compatibility, string maxvideos)
 	{
 		Response.Cookies.Append("hl", hl, new CookieOptions
 		{
@@ -53,6 +53,10 @@ public class SettingsController : Controller
 			Expires = DateTimeOffset.MaxValue
 		});
 		Response.Cookies.Append("compatibility", recommendations == "on" ? "true" : "false", new CookieOptions
+		{
+			Expires = DateTimeOffset.MaxValue
+		});
+  		Response.Cookies.Append("maxvideos", maxvideos, new CookieOptions
 		{
 			Expires = DateTimeOffset.MaxValue
 		});

--- a/LightTube/Controllers/SettingsController.cs
+++ b/LightTube/Controllers/SettingsController.cs
@@ -34,7 +34,7 @@ public class SettingsController : Controller
 
 	[Route("appearance")]
 	[HttpPost]
-	public IActionResult Appearance(string hl, string gl, string theme, string recommendations, string compatibility, string maxvideos)
+	public IActionResult Appearance(string hl, string gl, string theme, string recommendations, string compatibility)
 	{
 		Response.Cookies.Append("hl", hl, new CookieOptions
 		{
@@ -53,10 +53,6 @@ public class SettingsController : Controller
 			Expires = DateTimeOffset.MaxValue
 		});
 		Response.Cookies.Append("compatibility", recommendations == "on" ? "true" : "false", new CookieOptions
-		{
-			Expires = DateTimeOffset.MaxValue
-		});
-		Response.Cookies.Append("maxvideos", maxvideos, new CookieOptions
 		{
 			Expires = DateTimeOffset.MaxValue
 		});

--- a/LightTube/Controllers/SettingsController.cs
+++ b/LightTube/Controllers/SettingsController.cs
@@ -34,7 +34,7 @@ public class SettingsController : Controller
 
 	[Route("appearance")]
 	[HttpPost]
-	public IActionResult Appearance(string hl, string gl, string theme, string recommendations)
+	public IActionResult Appearance(string hl, string gl, string theme, string recommendations, string compatibility, string maxvideos)
 	{
 		Response.Cookies.Append("hl", hl, new CookieOptions
 		{
@@ -49,6 +49,14 @@ public class SettingsController : Controller
 			Expires = DateTimeOffset.MaxValue
 		});
 		Response.Cookies.Append("recommendations", recommendations == "on" ? "visible" : "collapsed", new CookieOptions
+		{
+			Expires = DateTimeOffset.MaxValue
+		});
+		Response.Cookies.Append("compatibility", recommendations == "on" ? "true" : "false", new CookieOptions
+		{
+			Expires = DateTimeOffset.MaxValue
+		});
+		Response.Cookies.Append("maxvideos", maxvideos, new CookieOptions
 		{
 			Expires = DateTimeOffset.MaxValue
 		});

--- a/LightTube/Views/Home/Index.cshtml
+++ b/LightTube/Views/Home/Index.cshtml
@@ -1,3 +1,32 @@
-﻿<div style="display: flex;align-items: center;justify-content: center;width: 100%;height: 100%">
-	<h1 style="color:var(--text-primary);text-align:center">@Configuration.GetVariable("LIGHTTUBE_MOTD", "Search something to get started!")</h1>
+﻿<div style="display: flex;align-items: center;justify-content: center">
+	<h1 style="color:var(--text-primary);text-align:center;height:10%">@Configuration.GetVariable("LIGHTTUBE_MOTD", "Search something to get started!")</h1>
 </div>
+@if (Model.Videos is not null)
+{
+	@using Humanizer
+
+	<div class="renderer-gridrenderer">
+
+		@foreach (FeedVideo video in Model.Videos)
+		{
+					<div class="renderer-gridvideorenderer">
+						<a href="/watch?v=@video.Id"  class="grid-thumbnail">
+							<img loading="lazy" src="@video.Thumbnail" alt="@video.Title">
+						</a>
+						<div class="info">
+							<a href="/watch?v=@video.Id" class="ml-2 title" title="@video.Title">
+						@video.Title
+							</a>
+							<div class="info__channel">
+								<a href="/channel/@video.ChannelId" title="@video.ChannelName" class="ml-1">
+							@video.ChannelName
+								</a>
+							</div>
+							<div>
+						@video.ViewCount.ToString("N0") views • @video.PublishedDate.Humanize(DateTimeOffset.UtcNow)
+							</div>
+						</div>
+					</div>
+		}
+	</div>
+}

--- a/LightTube/Views/Home/Index.cshtml
+++ b/LightTube/Views/Home/Index.cshtml
@@ -1,9 +1,9 @@
-﻿<div style="display: flex;align-items: center;justify-content: center">
+﻿@using Humanizer
+<div style="display: flex;align-items: center;justify-content: center">
 	<h1 style="color:var(--text-primary);text-align:center;height:10%">@Configuration.GetVariable("LIGHTTUBE_MOTD", "Search something to get started!")</h1>
 </div>
 @if (Model.Videos is not null)
 {
-	@using Humanizer
 
 	<div class="renderer-gridrenderer">
 

--- a/LightTube/Views/Settings/Appearance.cshtml
+++ b/LightTube/Views/Settings/Appearance.cshtml
@@ -53,9 +53,24 @@
 
 <div class="settings-option">
 	<div class="settings-option__info">
+		<div class="ml-2 title">
+			Last videos
+		</div>
+		<div>
+			Show last n videos from subscribed feed on homepage
+		</div>
+	</div>
+	<div class="settings-option__option">
+		<input type="number" name="maxvideos" value="@Context.Request.Cookies["maxvideos"]" />
+	</div>
+</div>
+
+<div class="settings-option">
+	<div class="settings-option__info">
 		<div class="ml-1 title">
 			Content Language
 		</div>
+		
 		<div>
 			Only affects video title & descriptions
 		</div>

--- a/LightTube/Views/Settings/Appearance.cshtml
+++ b/LightTube/Views/Settings/Appearance.cshtml
@@ -61,7 +61,7 @@
 		</div>
 	</div>
 	<div class="settings-option__option">
-		<input type="number" name="maxvideos" value="@Context.Request.Cookies["maxvideos"]" />
+		<input type="number" name="maxvideos" value="@(Context.Request.Cookies["maxvideos"] is null ? "5":Context.Request.Cookies["maxvideos"])" />
 	</div>
 </div>
 

--- a/LightTube/wwwroot/css/lighttube.css
+++ b/LightTube/wwwroot/css/lighttube.css
@@ -1467,7 +1467,7 @@ select:active {
     width: 100%;
 }
 
-input[type=text] {
+input[type=text], input[type="number"] {
     background-color: var(--chip-background);
     padding: 4px 8px;
     border-radius: 32px;


### PR DESCRIPTION
# Details
Populate index page for logged in users with last 5 video of their subscribed channels.

# Related issues/PRs
Implements #70 

![image](https://github.com/kuylar/LightTube/assets/29955189/55ff32a3-a0fb-4070-85a8-b55c925cb57b)

