### PR TITLE
Fix the RSS feed not filtering with NOTIFICATIONS_ON

### DIFF
--- a/LightTube/Controllers/FeedController.cs
+++ b/LightTube/Controllers/FeedController.cs
@@ -47,7 +47,7 @@ public class FeedController : Controller
 			string password = secretDecoded.Split(':')[1];
 			DatabaseUser? user = await DatabaseManager.Users.GetUserFromUsernamePassword(username, password);
 			if (user is null) throw new Exception();
-			FeedVideo[] feedVideos = await YoutubeRSS.GetMultipleFeeds(user.Subscriptions.Keys);
+			FeedVideo[] feedVideos = await YoutubeRSS.GetMultipleFeeds(user.Subscriptions.Where(x => x.Value == SubscriptionType.NOTIFICATIONS_ON).Select(x => x.Key));
 
 			XmlDocument document = new();
 			XmlElement rss = document.CreateElement("rss");


### PR DESCRIPTION
# Details
The RSS feed wasn't filtering the subscribed channels, even if it was told to do so

# Changes proposed
* Make the RSS feed endpoint filter the keys before getting them